### PR TITLE
Remove Tunein search restriction as a known issue

### DIFF
--- a/docs/music-providers/tunein.md
+++ b/docs/music-providers/tunein.md
@@ -22,7 +22,3 @@ Music Assistant has support for [Tunein](https://tunein.com/)
 ## Configuration
 
 In the Generic Settings, add your Username.
-
-## Known Issues / Notes
-
-- You cannot search the TuneIn provider from within MA


### PR DESCRIPTION
The https://github.com/music-assistant/server/pull/2204 PR enables the search function for Tune-in music provider (https://github.com/orgs/music-assistant/discussions/2639)

![image](https://github.com/user-attachments/assets/46d0b917-d2ad-4dd7-a83f-c630ee8d9c97)