### PR TITLE
docs(yandex-music): My Wave — Features table, new section, Known Issues

### DIFF
--- a/docs/music-providers/yandex-music.md
+++ b/docs/music-providers/yandex-music.md
@@ -14,9 +14,9 @@ This provider is built on top of the [yandex-music-api](https://github.com/Marsh
 | Subscription FREE | Yes (with limitations) |
 | Self-Hosted Local Media | No |
 | Media Types Supported | Artists, Albums, Tracks, Playlists |
-| [Recommendations](../ui.md#view-home) Supported | No |
+| [Recommendations](../ui.md#view-home) Supported | Yes |
 | Lyrics Supported | No |
-| [Radio Mode](../ui.md#track-menu) | No |
+| [Radio Mode](../ui.md#track-menu) | Yes |
 | Maximum Stream Quality | Lossless FLAC (with Plus subscription) |
 | Login Method | Token |
 
@@ -26,6 +26,23 @@ This provider is built on top of the [yandex-music-api](https://github.com/Marsh
 - Items in a users Yandex Music library will be synced to Music Assistant
 - Adding/removing items to/from the Music Assistant library will sync back to Yandex Music
 - Browse is available to explore the Yandex Music catalogue
+- **My Wave (Моя волна)** — personalized track feed, recommendations in Discover, and radio mode (similar tracks via Rotor)
+
+## My Wave (Моя волна)
+
+My Wave is Yandex Music’s personalized track feed, powered by the Rotor API. It appears in several places in Music Assistant.
+
+### Sync and where it appears
+
+- **Browse:** A root folder “Моя волна” / “My Wave” (name depends on locale: Russian for `ru_*`, English otherwise). Opening it loads up to three batches of tracks so that starting playback adds more to the queue. A “Load more” / “Ещё” folder loads the next batch (pagination by first track in the chain in the API).
+- **Recommendations (Discover):** A single “Моя волна” section with the first batch of tracks.
+- **Library playlists:** A virtual playlist “Моя волна” is shown first in the playlists list; tracks are loaded in pages via `get_playlist_tracks` with pagination.
+
+### What you can do
+
+- Play from Browse (folder), from Discover, or from the “Моя волна” playlist in your library.
+- **Radio mode:** When you start radio from a Yandex Music track, similar tracks are added to the queue using the Rotor station `track:{id}`.
+- **Rotor feedback:** While playing My Wave, the provider sends `radioStarted`, `trackStarted`, `trackFinished` / skip events to the API to improve recommendations. On connection errors (e.g. “Server disconnected”), it reconnects and retries the request.
 
 ## Configuration
 
@@ -46,6 +63,7 @@ Configuration requires obtaining an OAuth token from Yandex Music.
 ## Known Issues / Notes
 
 - The token may expire and need to be refreshed periodically
+- During long My Wave sessions the API may occasionally disconnect; the provider will reconnect and retry automatically
 
 ## Not yet supported
 - Multiple Yandex Music accounts cannot be added as yet

--- a/docs/music-providers/yandex-music.md
+++ b/docs/music-providers/yandex-music.md
@@ -92,7 +92,7 @@
     - **Preload** — Downloads and decrypts the entire file before playback starts. This takes longer to begin playing, but enables seeking and shows an accurate progress bar. If the file is larger than the configured limit (default: 100 MB), Preload automatically falls back to Buffered mode.
 
     !!! tip
-        Most users should leave the streaming mode at **Buffered**. Only change it if you experience playback issues or specifically need seek support in lossless tracks.
+        Most users should leave the streaming mode at **Buffered**. If you experience stuttering on a slow or unstable connection, try increasing the **Stream buffer size** in advanced settings (default: 8 MB, up to 32 MB).
 
 === "Русский"
 
@@ -116,7 +116,7 @@
     - **Preload** — Загружает и дешифрует весь файл перед началом воспроизведения. Запуск занимает больше времени, но позволяет перемотку и показывает точный прогресс-бар. Если файл больше установленного лимита (по умолчанию: 100 МБ), Preload автоматически переключается на Buffered.
 
     !!! tip
-        Большинству пользователей следует оставить режим стриминга **Buffered**. Меняйте его только при проблемах с воспроизведением или если вам нужна перемотка в lossless-треках.
+        Большинству пользователей следует оставить режим стриминга **Buffered**. Если воспроизведение заикается при медленном или нестабильном соединении, попробуйте увеличить **Stream buffer size** в расширенных настройках (по умолчанию: 8 МБ, максимум 32 МБ).
 
 ## My Wave
 

--- a/docs/music-providers/yandex-music.md
+++ b/docs/music-providers/yandex-music.md
@@ -83,16 +83,7 @@
 
     You can change the quality at any time in the provider settings. The actual codec and bitrate are selected automatically when playback starts, based on what Yandex Music offers for each track.
 
-    ### FLAC Streaming Modes
-
-    When streaming encrypted FLAC tracks (Superb quality), you can choose how decryption is handled:
-
-    - **Direct** — Decrypts on-the-fly as data arrives. Uses the least memory but requires a fast device.
-    - **Buffered** (default, recommended) — Separates the download and decryption into an async queue. Works well on most hardware.
-    - **Preload** — Downloads and decrypts the entire file before playback starts. This takes longer to begin playing, but enables seeking and shows an accurate progress bar. If the file is larger than the configured limit (default: 100 MB), Preload automatically falls back to Buffered mode.
-
-    !!! tip
-        Most users should leave the streaming mode at **Buffered**. If you experience stuttering on a slow or unstable connection, try increasing the **Stream buffer size** in advanced settings (default: 8 MB, up to 32 MB).
+    Encrypted FLAC tracks are decrypted on-the-fly as data arrives. Seeking is handled by Music Assistant core via ffmpeg.
 
 === "Русский"
 
@@ -107,16 +98,7 @@
 
     Качество можно изменить в любое время в настройках провайдера. Кодек и битрейт выбираются автоматически при начале воспроизведения в зависимости от того, что Yandex Music предлагает для каждого трека.
 
-    ### Режимы стриминга FLAC
-
-    При воспроизведении зашифрованных FLAC-треков (качество Superb) можно выбрать способ дешифровки:
-
-    - **Direct** — Дешифровка на лету по мере поступления данных. Минимальное потребление памяти, но требуется быстрое устройство.
-    - **Buffered** (по умолчанию, рекомендуется) — Загрузка и дешифровка разделены в асинхронную очередь. Хорошо работает на большинстве устройств.
-    - **Preload** — Загружает и дешифрует весь файл перед началом воспроизведения. Запуск занимает больше времени, но позволяет перемотку и показывает точный прогресс-бар. Если файл больше установленного лимита (по умолчанию: 100 МБ), Preload автоматически переключается на Buffered.
-
-    !!! tip
-        Большинству пользователей следует оставить режим стриминга **Buffered**. Если воспроизведение заикается при медленном или нестабильном соединении, попробуйте увеличить **Stream buffer size** в расширенных настройках (по умолчанию: 8 МБ, максимум 32 МБ).
+    Зашифрованные FLAC-треки дешифруются на лету по мере поступления данных. Перемотка обрабатывается ядром Music Assistant через ffmpeg.
 
 ## My Wave
 
@@ -348,7 +330,7 @@
 
     ### Settings
 
-    The provider has 9 settings. The first 3 are shown by default; the rest are under "Show advanced settings."
+    The provider has 6 settings. The first 3 are shown by default; the rest are under "Show advanced settings."
 
     | Setting | Default | Description |
     |---------|---------|-------------|
@@ -360,9 +342,6 @@
 
     | Setting | Default | Description |
     |---------|---------|-------------|
-    | **FLAC streaming mode** | Buffered | How encrypted FLAC streams are decoded (Direct, Buffered, or Preload) |
-    | **Preload max file size (MB)** | 100 | Only visible when Preload mode is selected. Files larger than this use Buffered mode instead |
-    | **Stream buffer size (MB)** | 8 | Only visible when Buffered mode is selected. Larger values help with slow or unstable connections by buffering more audio ahead of playback (~45 sec of FLAC at 8 MB). Range: 1–32 MB |
     | **My Wave maximum tracks** | 150 | How many tracks to load for My Wave. Lower = faster loading |
     | **Liked Tracks maximum tracks** | 500 | How many liked tracks to show. Lower = faster loading |
     | **API Base URL** | api.music.yandex.net | Only change if Yandex changes their API endpoint |
@@ -379,7 +358,7 @@
 
     ### Настройки
 
-    Провайдер имеет 9 настроек. Первые 3 отображаются по умолчанию; остальные доступны через «Show advanced settings».
+    Провайдер имеет 6 настроек. Первые 3 отображаются по умолчанию; остальные доступны через «Show advanced settings».
 
     | Настройка | По умолчанию | Описание |
     |-----------|-------------|----------|
@@ -391,9 +370,6 @@
 
     | Настройка | По умолчанию | Описание |
     |-----------|-------------|----------|
-    | **FLAC streaming mode** | Buffered | Способ дешифровки FLAC-потоков (Direct, Buffered или Preload) |
-    | **Preload max file size (MB)** | 100 | Отображается только при выборе Preload. Файлы больше этого размера используют Buffered |
-    | **Stream buffer size (MB)** | 8 | Отображается только при выборе Buffered. Увеличение помогает при медленном или нестабильном соединении, буферизуя больше аудио перед воспроизведением (~45 сек FLAC при 8 МБ). Диапазон: 1–32 МБ |
     | **My Wave maximum tracks** | 150 | Сколько треков загружать для Моей волны. Меньше = быстрее загрузка |
     | **Liked Tracks maximum tracks** | 500 | Сколько избранных треков показывать. Меньше = быстрее загрузка |
     | **API Base URL** | api.music.yandex.net | Менять только если Яндекс изменит адрес API |

--- a/docs/music-providers/yandex-music.md
+++ b/docs/music-providers/yandex-music.md
@@ -276,7 +276,7 @@
 
 === "English"
 
-    The home page shows up to 9 recommendation sections. All sections are always enabled — there are no toggles to show or hide individual sections.
+    The home page shows up to 9 recommendation sections. Each section can be shown or hidden, and its position can be changed, via the [Edit Homescreen](../ui.md#view-home) feature (blue icon in the top right of the home page).
 
     | Section | What it shows | How often it refreshes |
     |---------|--------------|----------------------|
@@ -294,7 +294,7 @@
 
 === "Русский"
 
-    На главной странице отображается до 9 секций рекомендаций. Все секции всегда включены — нет переключателей для отображения или скрытия отдельных секций.
+    На главной странице отображается до 9 секций рекомендаций. Каждую секцию можно показать или скрыть, а также изменить её позицию через функцию [Edit Homescreen](../ui.md#view-home) (синяя иконка в правом верхнем углу главной страницы).
 
     | Секция | Что показывает | Частота обновления |
     |--------|---------------|-------------------|

--- a/docs/music-providers/yandex-music.md
+++ b/docs/music-providers/yandex-music.md
@@ -215,17 +215,29 @@
     ```
     Yandex Music
     ├── Picks
-    │   ├── Mood — Chill, Sad, Romantic, Party, Relax
-    │   ├── Activity — Workout, Focus, Morning, Evening, Driving
-    │   ├── Era — 80s, 90s, 2000s, Retro
-    │   └── Genres — Rock, Jazz, Classical, Electronic, R&B, Hip-Hop
+    │   ├── Mood      (e.g. Chill, Sad, Romantic, Party, Relax, ...)
+    │   ├── Activity  (e.g. Workout, Focus, Morning, Evening, Driving, ...)
+    │   ├── Era       (e.g. 80s, 90s, 2000s, Retro, ...)
+    │   └── Genres    (e.g. Rock, Jazz, Classical, Electronic, R&B, Hip-Hop, ...)
     └── Mixes
-        └── Seasonal — Winter, Summer, Autumn, New Year
+        └── Seasonal  (e.g. Winter, Summer, Autumn, New Year, ...)
     ```
 
-    The categories under Picks contain fixed tags, but additional tags may be discovered dynamically from Yandex Music's catalog (refreshed hourly). These extra tags appear in the Mood category.
+    ### Dynamic tag discovery
 
-    Each tag opens a list of curated playlists you can play directly.
+    All tags are **discovered dynamically** from the Yandex Music Landing API — the provider does not rely on a hardcoded list. Only tags that Yandex actually returns are shown, which means:
+
+    - **No empty folders** — if a tag doesn't exist in the current API response, it simply won't appear
+    - **New tags appear automatically** — when Yandex adds new curated collections, they show up without a provider update
+    - **Categories are hidden when empty** — if no tags were discovered for a category (e.g. Era), the folder is not shown
+
+    Discovered tags are categorized into Mood, Activity, Era, or Genres using an internal mapping. Tags not in the mapping default to the Mood category. Useless tags (like "Albums with video shots") are blacklisted and filtered out.
+
+    Tag discovery results are cached for 1 hour. Tag playlist contents are cached for 10 minutes.
+
+    ### Playback behavior
+
+    Category and tag folders have **Play disabled** (`is_playable=False`). This prevents accidentally queuing thousands of tracks when pressing Play on a folder that contains playlists. To play music, navigate into a specific tag and choose a playlist.
 
 === "Русский"
 
@@ -236,17 +248,29 @@
     ```
     Yandex Music
     ├── Подборки (Picks)
-    │   ├── Настроение — Chill, Sad, Romantic, Party, Relax
-    │   ├── Активность — Workout, Focus, Morning, Evening, Driving
-    │   ├── Эпоха — 80s, 90s, 2000s, Retro
-    │   └── Жанры — Rock, Jazz, Classical, Electronic, R&B, Hip-Hop
+    │   ├── Настроение  (напр. Chill, Sad, Romantic, Party, Relax, ...)
+    │   ├── Активность   (напр. Workout, Focus, Morning, Evening, Driving, ...)
+    │   ├── Эпоха        (напр. 80s, 90s, 2000s, Retro, ...)
+    │   └── Жанры        (напр. Rock, Jazz, Classical, Electronic, R&B, Hip-Hop, ...)
     └── Миксы (Mixes)
-        └── Сезонные — Winter, Summer, Autumn, New Year
+        └── Сезонные     (напр. Winter, Summer, Autumn, New Year, ...)
     ```
 
-    Категории в Подборках содержат фиксированные теги, но дополнительные теги могут обнаруживаться динамически из каталога Yandex Music (обновление каждый час). Дополнительные теги отображаются в категории Mood.
+    ### Динамическое обнаружение тегов
 
-    Каждый тег открывает список тематических плейлистов, которые можно воспроизвести напрямую.
+    Все теги **обнаруживаются динамически** через Landing API Yandex Music — провайдер не использует фиксированный список. Показываются только теги, которые Яндекс реально вернул, что означает:
+
+    - **Нет пустых папок** — если тег не существует в текущем ответе API, он просто не отображается
+    - **Новые теги появляются автоматически** — когда Яндекс добавляет новые подборки, они показываются без обновления провайдера
+    - **Пустые категории скрываются** — если для категории (например, Эпоха) не нашлось ни одного тега, папка не отображается
+
+    Обнаруженные теги распределяются по категориям Настроение, Активность, Эпоха, Жанры через внутренний маппинг. Теги вне маппинга попадают в категорию Настроение. Бесполезные теги (например, «Альбомы с видеошотами») добавлены в чёрный список и отфильтровываются.
+
+    Результаты обнаружения тегов кэшируются на 1 час. Содержимое плейлистов тегов кэшируется на 10 минут.
+
+    ### Поведение воспроизведения
+
+    У папок категорий и тегов **отключена кнопка Play** (`is_playable=False`). Это предотвращает случайную загрузку тысяч треков при нажатии Play на папке, содержащей плейлисты. Для воспроизведения музыки нужно зайти в конкретный тег и выбрать плейлист.
 
 ## Home Page Recommendations
 

--- a/docs/music-providers/yandex-music.md
+++ b/docs/music-providers/yandex-music.md
@@ -26,23 +26,97 @@ This provider is built on top of the [yandex-music-api](https://github.com/Marsh
 - Items in a users Yandex Music library will be synced to Music Assistant
 - Adding/removing items to/from the Music Assistant library will sync back to Yandex Music
 - Browse is available to explore the Yandex Music catalogue
-- **My Wave (Моя волна)** — personalized track feed, recommendations in Discover, and radio mode (similar tracks via Rotor)
+- **My Wave (Моя волна)** — personalized track feed, recommendations in Discover, and radio mode
+- **Picks & Mixes** — curated playlists by mood, activity, era, genre, and season
+- **Extended recommendations** — Made for You, Chart, New Releases, New Playlists on home page
+
+## Audio Quality
+
+Four quality tiers are available:
+
+| Quality | Format | Bitrate | Requirements |
+|---------|--------|---------|--------------|
+| Efficient | AAC | ~64 kbps | Free account |
+| Balanced | AAC | ~192 kbps | Free account |
+| High | MP3 | ~320 kbps | Free account |
+| Superb | FLAC | Lossless | Plus subscription |
+
+### FLAC Streaming Modes
+
+For encrypted FLAC streams, three streaming modes are available:
+
+- **Direct** — On-the-fly decryption, best for fast devices
+- **Buffered** — Async queue decoupling download from decryption (recommended)
+- **Preload** — Full file download before playback, enables seek and accurate progress bar
 
 ## My Wave (Моя волна)
 
-My Wave is Yandex Music’s personalized track feed, powered by the Rotor API. It appears in several places in Music Assistant.
+My Wave is Yandex Music's personalized track feed, powered by the Rotor API. It appears in several places in Music Assistant.
 
-### Sync and where it appears
+### Where it appears
 
-- **Browse:** A root folder “Моя волна” / “My Wave” (name depends on locale: Russian for `ru_*`, English otherwise). Opening it loads up to three batches of tracks so that starting playback adds more to the queue. A “Load more” / “Ещё” folder loads the next batch (pagination by first track in the chain in the API).
-- **Recommendations (Discover):** A single “Моя волна” section with the first batch of tracks.
-- **Library playlists:** A virtual playlist “Моя волна” is shown first in the playlists list; tracks are loaded in pages via `get_playlist_tracks` with pagination.
+- **Browse:** A root folder "Моя волна" / "My Wave" (locale-dependent). Opening it loads multiple batches of tracks. A "Load more" folder loads the next batch.
+- **Recommendations (Discover):** A "Моя волна" section with personalized tracks.
+- **Library playlists:** A virtual playlist "Моя волна" in your playlists list.
 
 ### What you can do
 
-- Play from Browse (folder), from Discover, or from the “Моя волна” playlist in your library.
-- **Radio mode:** When you start radio from a Yandex Music track, similar tracks are added to the queue using the Rotor station `track:{id}`.
-- **Rotor feedback:** While playing My Wave, the provider sends `radioStarted`, `trackStarted`, `trackFinished` / skip events to the API to improve recommendations. On connection errors (e.g. “Server disconnected”), it reconnects and retries the request.
+- Play from Browse, Discover, or the playlist in your library
+- **Radio mode:** Start radio from any Yandex Music track to get similar tracks via Rotor
+- **Rotor feedback:** The provider sends play events to Yandex to improve recommendations
+
+### Configuration options
+
+- Enable/disable My Wave in Browse, Discover, and library playlists
+- Maximum tracks limit (default: 150)
+- Batch count for loading (default: 3)
+- Radio mode feedback toggle
+
+## Liked Tracks
+
+Your liked/favorited tracks are available as a virtual playlist with these features:
+
+- **Reverse chronological sorting** — most recent likes first
+- **Browse folder** — optional folder in Browse section
+- **Virtual playlist** — appears in your library playlists
+- **Configurable limit** — default 500 tracks
+
+## Picks & Mixes
+
+Curated playlists organized by category, available in Browse and on the home page.
+
+### Browse structure
+
+```
+Yandex Music
+├── Picks (Подборки)
+│   ├── Mood — Chill, Sad, Romantic, Party, Relax
+│   ├── Activity — Workout, Focus, Morning, Evening, Driving
+│   ├── Era — 80s, 90s, 2000s, Retro
+│   └── Genres — Rock, Jazz, Classical, Electronic, R&B, Hip-Hop
+└── Mixes (Миксы)
+    └── Seasonal — Winter, Summer, Autumn, New Year
+```
+
+### Discovery sections
+
+| Section | Description | Rotation |
+|---------|-------------|----------|
+| Top Picks | Top curated playlists | Hourly |
+| Mood Mix | Rotating mood playlists (chill, sad, romantic...) | Every 30 min |
+| Activity Mix | Rotating activity playlists (workout, focus...) | Every 30 min |
+| Seasonal Mix | Season-based playlists | Every 6 hours |
+
+## Extended Recommendations
+
+Additional sections on the home page:
+
+- **Made for You** — Playlist of the Day, DejaVu, Premiere, and other personalized playlists
+- **Chart** — Top chart tracks
+- **New Releases** — Latest album releases
+- **New Playlists** — Fresh editorial playlists
+
+Each section can be enabled or disabled independently in settings.
 
 ## Configuration
 
@@ -56,14 +130,33 @@ Configuration requires obtaining an OAuth token from Yandex Music.
 4. Copy the token value (the part after `access_token=` and before `&`)
 5. Paste this token into the Music Assistant Yandex Music provider configuration
 
-### Settings
+### Settings Categories
 
-- **Audio quality**: Select preferred audio quality. The default is `High (320 kbps)` which is available for all accounts. The other option is `Lossless (FLAC)` which requires a Yandex Music Plus subscription
+Settings are organized into categories for easier navigation:
+
+| Category | Settings |
+|----------|----------|
+| **My Wave** | Enable in Browse/Discover/Playlists, max tracks, batch count, radio feedback |
+| **Liked Tracks** | Enable in Browse/Playlists, max tracks |
+| **Discovery** | Made for You, Chart, New Releases, New Playlists toggles |
+| **Picks & Mixes** | Enable Picks/Mixes in Browse, Top Picks, Mood/Activity/Seasonal Mix on home |
+| **Streaming** | FLAC streaming mode, Preload max file size |
+| **Advanced** | Track batch size, initial tracks limits, API base URL |
+
+## Localization
+
+All folder names and labels are available in Russian and English. The language is determined automatically based on Music Assistant locale settings:
+
+- Russian (`ru_*` locales): "Моя волна", "Подборки", "Миксы", etc.
+- Other locales: "My Wave", "Picks", "Mixes", etc.
 
 ## Known Issues / Notes
 
 - The token may expire and need to be refreshed periodically
-- During long My Wave sessions the API may occasionally disconnect; the provider will reconnect and retry automatically
+- During long sessions the API may occasionally disconnect; the provider reconnects automatically
+- Some curated playlists may be unavailable in certain regions due to geo-restrictions
 
 ## Not yet supported
+
 - Multiple Yandex Music accounts cannot be added as yet
+- Lyrics are not currently supported

--- a/docs/music-providers/yandex-music.md
+++ b/docs/music-providers/yandex-music.md
@@ -15,7 +15,7 @@ This provider is built on top of the [yandex-music-api](https://github.com/Marsh
 | Self-Hosted Local Media | No |
 | Media Types Supported | Artists, Albums, Tracks, Playlists |
 | [Recommendations](../ui.md#view-home) Supported | Yes |
-| Lyrics Supported | No |
+| Lyrics Supported | Yes |
 | [Radio Mode](../ui.md#track-menu) | Yes |
 | Maximum Stream Quality | Lossless FLAC (with Plus subscription) |
 | Login Method | Token |
@@ -29,6 +29,7 @@ This provider is built on top of the [yandex-music-api](https://github.com/Marsh
 - **My Wave (Моя волна)** — personalized track feed, recommendations in Discover, and radio mode
 - **Picks & Mixes** — curated playlists by mood, activity, era, genre, and season
 - **Extended recommendations** — Made for You, Chart, New Releases, New Playlists on home page
+- **Lyrics** — synced (LRC) and plain text lyrics from Yandex Music
 
 ## Audio Quality
 
@@ -118,6 +119,17 @@ Additional sections on the home page:
 
 Each section can be enabled or disabled independently in settings.
 
+## Lyrics
+
+Lyrics are fetched directly from Yandex Music when viewing track details.
+
+- **Synced lyrics (LRC)** — With timestamps for karaoke-style synchronized display
+- **Plain text lyrics** — When synced lyrics are not available
+- **Automatic caching** — Lyrics are cached for 30 days
+
+!!! note
+    Lyrics availability depends on the track and may vary by region due to licensing restrictions.
+
 ## Configuration
 
 Configuration requires obtaining an OAuth token from Yandex Music.
@@ -159,4 +171,3 @@ All folder names and labels are available in Russian and English. The language i
 ## Not yet supported
 
 - Multiple Yandex Music accounts cannot be added as yet
-- Lyrics are not currently supported

--- a/docs/music-providers/yandex-music.md
+++ b/docs/music-providers/yandex-music.md
@@ -348,7 +348,7 @@
 
     ### Settings
 
-    The provider has 8 settings. The first 3 are shown by default; the rest are under "Show advanced settings."
+    The provider has 9 settings. The first 3 are shown by default; the rest are under "Show advanced settings."
 
     | Setting | Default | Description |
     |---------|---------|-------------|
@@ -362,6 +362,7 @@
     |---------|---------|-------------|
     | **FLAC streaming mode** | Buffered | How encrypted FLAC streams are decoded (Direct, Buffered, or Preload) |
     | **Preload max file size (MB)** | 100 | Only visible when Preload mode is selected. Files larger than this use Buffered mode instead |
+    | **Stream buffer size (MB)** | 8 | Only visible when Buffered mode is selected. Larger values help with slow or unstable connections by buffering more audio ahead of playback (~45 sec of FLAC at 8 MB). Range: 1–32 MB |
     | **My Wave maximum tracks** | 150 | How many tracks to load for My Wave. Lower = faster loading |
     | **Liked Tracks maximum tracks** | 500 | How many liked tracks to show. Lower = faster loading |
     | **API Base URL** | api.music.yandex.net | Only change if Yandex changes their API endpoint |
@@ -378,7 +379,7 @@
 
     ### Настройки
 
-    Провайдер имеет 8 настроек. Первые 3 отображаются по умолчанию; остальные доступны через «Show advanced settings».
+    Провайдер имеет 9 настроек. Первые 3 отображаются по умолчанию; остальные доступны через «Show advanced settings».
 
     | Настройка | По умолчанию | Описание |
     |-----------|-------------|----------|
@@ -392,6 +393,7 @@
     |-----------|-------------|----------|
     | **FLAC streaming mode** | Buffered | Способ дешифровки FLAC-потоков (Direct, Buffered или Preload) |
     | **Preload max file size (MB)** | 100 | Отображается только при выборе Preload. Файлы больше этого размера используют Buffered |
+    | **Stream buffer size (MB)** | 8 | Отображается только при выборе Buffered. Увеличение помогает при медленном или нестабильном соединении, буферизуя больше аудио перед воспроизведением (~45 сек FLAC при 8 МБ). Диапазон: 1–32 МБ |
     | **My Wave maximum tracks** | 150 | Сколько треков загружать для Моей волны. Меньше = быстрее загрузка |
     | **Liked Tracks maximum tracks** | 500 | Сколько избранных треков показывать. Меньше = быстрее загрузка |
     | **API Base URL** | api.music.yandex.net | Менять только если Яндекс изменит адрес API |

--- a/docs/music-providers/yandex-music.md
+++ b/docs/music-providers/yandex-music.md
@@ -1,191 +1,405 @@
 # Yandex Music Provider ![Preview image](../assets/icons/yandex-music-icon.svg){ width=50 align=right }
 
-Music Assistant has support for [Yandex Music](https://music.yandex.ru). Contributed and maintained by [TrudenBoy](https://github.com/TrudenBoy).
+=== "English"
 
-This provider is built on top of the [yandex-music-api](https://github.com/MarshalX/yandex-music-api) library.
+    Music Assistant has support for [Yandex Music](https://music.yandex.ru). Contributed and maintained by [TrudenBoy](https://github.com/TrudenBoy).
 
-!!! note
-    A Yandex Music Plus subscription is required for lossless (FLAC) quality. Standard accounts can stream up to high quality (320 kbps MP3).
+    This provider is built on top of the [yandex-music-api](https://github.com/MarshalX/yandex-music-api) library.
+
+    !!! note
+        A Yandex Music Plus subscription is required for lossless (FLAC) quality. Standard accounts can stream up to high quality (320 kbps MP3).
+
+=== "Русский"
+
+    Music Assistant поддерживает [Yandex Music](https://music.yandex.ru). Разработка и поддержка — [TrudenBoy](https://github.com/TrudenBoy).
+
+    Провайдер построен на основе библиотеки [yandex-music-api](https://github.com/MarshalX/yandex-music-api).
+
+    !!! note
+        Для воспроизведения в lossless-качестве (FLAC) необходима подписка Yandex Music Plus. Без подписки доступно качество до 320 кбит/с MP3.
 
 ## Features
 
-|           |                     |
-|:-----------------------|:---------------------:|
-| Subscription FREE | Yes (with limitations) |
-| Self-Hosted Local Media | No |
-| Media Types Supported | Artists, Albums, Tracks, Playlists |
-| [Recommendations](../ui.md#view-home) Supported | Yes |
-| Lyrics Supported | Yes |
-| [Radio Mode](../ui.md#track-menu) | Yes |
-| Maximum Stream Quality | Lossless FLAC (with Plus subscription) |
-| Login Method | Token |
+=== "English"
 
-### Other
+    |           |                     |
+    |:-----------------------|:---------------------:|
+    | Subscription FREE | Yes (with limitations) |
+    | Self-Hosted Local Media | No |
+    | Media Types Supported | Artists, Albums, Tracks, Playlists |
+    | [Recommendations](../ui.md#view-home) Supported | Yes |
+    | Lyrics Supported | Yes |
+    | [Radio Mode](../ui.md#track-menu) | Yes |
+    | Maximum Stream Quality | Lossless FLAC (with Plus subscription) |
+    | Login Method | Token |
 
-- Searching the Yandex Music catalogue is possible
-- Items in a users Yandex Music library will be synced to Music Assistant
-- Adding/removing items to/from the Music Assistant library will sync back to Yandex Music
-- Browse is available to explore the Yandex Music catalogue
-- **My Wave** — personalized infinite radio powered by Yandex's AI
-- **Picks & Mixes** — curated playlists organized by mood, activity, era, genre, and season
-- **Extended recommendations** — Made for You, Chart, New Releases, New Playlists, and more on the home page
-- **Lyrics** — synced (LRC) and plain text lyrics
+    ### Other
+
+    - Searching the Yandex Music catalogue is possible
+    - Items in a users Yandex Music library will be synced to Music Assistant
+    - Adding/removing items to/from the Music Assistant library will sync back to Yandex Music
+    - Browse is available to explore the Yandex Music catalogue
+    - **My Wave** — personalized infinite radio powered by Yandex's AI
+    - **Picks & Mixes** — curated playlists organized by mood, activity, era, genre, and season
+    - **Extended recommendations** — Made for You, Chart, New Releases, New Playlists, and more on the home page
+    - **Lyrics** — synced (LRC) and plain text lyrics
+
+=== "Русский"
+
+    |           |                     |
+    |:-----------------------|:---------------------:|
+    | Бесплатная подписка | Да (с ограничениями) |
+    | Локальные медиафайлы | Нет |
+    | Поддерживаемые типы | Исполнители, Альбомы, Треки, Плейлисты |
+    | [Рекомендации](../ui.md#view-home) | Да |
+    | Тексты песен | Да |
+    | [Режим радио](../ui.md#track-menu) | Да |
+    | Максимальное качество | Lossless FLAC (с подпиской Plus) |
+    | Способ входа | Токен |
+
+    ### Дополнительно
+
+    - Поиск по каталогу Yandex Music
+    - Библиотека пользователя Yandex Music синхронизируется с Music Assistant
+    - Добавление/удаление элементов в библиотеке Music Assistant синхронизируется обратно в Yandex Music
+    - Раздел Browse для навигации по каталогу Yandex Music
+    - **Моя волна** — персонализированное бесконечное радио на основе ИИ Яндекса
+    - **Подборки и Миксы** — плейлисты по настроению, активности, эпохе, жанру и сезону
+    - **Расширенные рекомендации** — Собрано для вас, Чарт, Новинки, Новые плейлисты и другое на главной странице
+    - **Тексты песен** — синхронизированные (LRC) и обычные тексты
 
 ## Audio Quality
 
-Four quality tiers are available:
+=== "English"
 
-| Quality | Format | Bitrate | Requirements |
-|---------|--------|---------|--------------|
-| Efficient | AAC | ~64 kbps | Free account |
-| Balanced (default) | AAC | ~192 kbps | Free account |
-| High | MP3 | ~320 kbps | Free account |
-| Superb | FLAC | Lossless | Plus subscription |
+    Four quality tiers are available:
 
-You can change the quality at any time in the provider settings. The actual codec and bitrate are selected automatically when playback starts, based on what Yandex Music offers for each track.
+    | Quality | Format | Bitrate | Requirements |
+    |---------|--------|---------|--------------|
+    | Efficient | AAC | ~64 kbps | Free account |
+    | Balanced (default) | AAC | ~192 kbps | Free account |
+    | High | MP3 | ~320 kbps | Free account |
+    | Superb | FLAC | Lossless | Plus subscription |
 
-### FLAC Streaming Modes
+    You can change the quality at any time in the provider settings. The actual codec and bitrate are selected automatically when playback starts, based on what Yandex Music offers for each track.
 
-When streaming encrypted FLAC tracks (Superb quality), you can choose how decryption is handled:
+    ### FLAC Streaming Modes
 
-- **Direct** — Decrypts on-the-fly as data arrives. Uses the least memory but requires a fast device.
-- **Buffered** (default, recommended) — Separates the download and decryption into an async queue. Works well on most hardware.
-- **Preload** — Downloads and decrypts the entire file before playback starts. This takes longer to begin playing, but enables seeking and shows an accurate progress bar. If the file is larger than the configured limit (default: 100 MB), Preload automatically falls back to Buffered mode.
+    When streaming encrypted FLAC tracks (Superb quality), you can choose how decryption is handled:
 
-!!! tip
-    Most users should leave the streaming mode at **Buffered**. Only change it if you experience playback issues or specifically need seek support in lossless tracks.
+    - **Direct** — Decrypts on-the-fly as data arrives. Uses the least memory but requires a fast device.
+    - **Buffered** (default, recommended) — Separates the download and decryption into an async queue. Works well on most hardware.
+    - **Preload** — Downloads and decrypts the entire file before playback starts. This takes longer to begin playing, but enables seeking and shows an accurate progress bar. If the file is larger than the configured limit (default: 100 MB), Preload automatically falls back to Buffered mode.
+
+    !!! tip
+        Most users should leave the streaming mode at **Buffered**. Only change it if you experience playback issues or specifically need seek support in lossless tracks.
+
+=== "Русский"
+
+    Доступны четыре уровня качества:
+
+    | Качество | Формат | Битрейт | Требования |
+    |----------|--------|---------|------------|
+    | Efficient | AAC | ~64 кбит/с | Бесплатный аккаунт |
+    | Balanced (по умолчанию) | AAC | ~192 кбит/с | Бесплатный аккаунт |
+    | High | MP3 | ~320 кбит/с | Бесплатный аккаунт |
+    | Superb | FLAC | Lossless | Подписка Plus |
+
+    Качество можно изменить в любое время в настройках провайдера. Кодек и битрейт выбираются автоматически при начале воспроизведения в зависимости от того, что Yandex Music предлагает для каждого трека.
+
+    ### Режимы стриминга FLAC
+
+    При воспроизведении зашифрованных FLAC-треков (качество Superb) можно выбрать способ дешифровки:
+
+    - **Direct** — Дешифровка на лету по мере поступления данных. Минимальное потребление памяти, но требуется быстрое устройство.
+    - **Buffered** (по умолчанию, рекомендуется) — Загрузка и дешифровка разделены в асинхронную очередь. Хорошо работает на большинстве устройств.
+    - **Preload** — Загружает и дешифрует весь файл перед началом воспроизведения. Запуск занимает больше времени, но позволяет перемотку и показывает точный прогресс-бар. Если файл больше установленного лимита (по умолчанию: 100 МБ), Preload автоматически переключается на Buffered.
+
+    !!! tip
+        Большинству пользователей следует оставить режим стриминга **Buffered**. Меняйте его только при проблемах с воспроизведением или если вам нужна перемотка в lossless-треках.
 
 ## My Wave
 
-My Wave is Yandex Music's personalized infinite radio. It uses Yandex's Rotor recommendation engine to generate a continuous stream of tracks tailored to your listening habits.
+=== "English"
 
-### How it works
+    My Wave is Yandex Music's personalized infinite radio. It uses Yandex's Rotor recommendation engine to generate a continuous stream of tracks tailored to your listening habits.
 
-1. When you open My Wave, the provider requests several batches of tracks from Yandex's Rotor API (the same engine behind "My Wave" in the official Yandex Music app).
-2. Each batch contains a few tracks. The provider fetches multiple batches at once to give you a longer playlist to start with.
-3. Duplicate tracks are automatically filtered out — if a track appeared in a previous batch, it won't show up again.
-4. In Browse, a **"Load more"** button appears at the bottom. Tapping it fetches the next batch and adds more tracks.
-5. The maximum number of tracks is configurable (default: 150). Once the limit is reached, no more tracks are loaded.
+    ### How it works
 
-### Improving your recommendations
+    1. When you open My Wave, the provider requests several batches of tracks from Yandex's Rotor API (the same engine behind "My Wave" in the official Yandex Music app).
+    2. Each batch contains a few tracks. The provider fetches multiple batches at once to give you a longer playlist to start with.
+    3. Duplicate tracks are automatically filtered out — if a track appeared in a previous batch, it won't show up again.
+    4. In Browse, a **"Load more"** button appears at the bottom. Tapping it fetches the next batch and adds more tracks.
+    5. The maximum number of tracks is configurable (default: 150). Once the limit is reached, no more tracks are loaded.
 
-The provider sends playback feedback to Yandex, similar to what the official app does:
+    ### Improving your recommendations
 
-- When you **start playing** a track, Yandex is notified.
-- When you **finish** a track (listen to nearly the end), Yandex counts it as "liked."
-- When you **skip** a track (stop before the end), Yandex adjusts future recommendations accordingly.
+    The provider sends playback feedback to Yandex, similar to what the official app does:
 
-This feedback happens automatically — you don't need to do anything. Over time, Yandex learns your preferences and My Wave becomes more personalized.
+    - When you **start playing** a track, Yandex is notified.
+    - When you **finish** a track (listen to nearly the end), Yandex counts it as "liked."
+    - When you **skip** a track (stop before the end), Yandex adjusts future recommendations accordingly.
 
-### Where My Wave appears
+    This feedback happens automatically — you don't need to do anything. Over time, Yandex learns your preferences and My Wave becomes more personalized.
 
-- **Browse** — A "My Wave" folder at the root of Yandex Music. You can play it directly or browse individual tracks.
-- **Home page (Discover)** — A "My Wave" recommendation section with a selection of personalized tracks.
-- **Library playlists** — A virtual "My Wave" playlist always appears in your playlist list for quick access.
+    ### Where My Wave appears
 
-### Similar tracks (Radio mode)
+    - **Browse** — A "My Wave" folder at the root of Yandex Music. You can play it directly or browse individual tracks.
+    - **Home page (Discover)** — A "My Wave" recommendation section with a selection of personalized tracks.
+    - **Library playlists** — A virtual "My Wave" playlist always appears in your playlist list for quick access.
 
-When you start radio mode from any Yandex Music track, the provider uses Yandex's Rotor engine to find similar tracks. This works for any track, not just My Wave — it creates a station based on that specific track's style and genre.
+    ### Similar tracks (Radio mode)
+
+    When you start radio mode from any Yandex Music track, the provider uses Yandex's Rotor engine to find similar tracks. This works for any track, not just My Wave — it creates a station based on that specific track's style and genre.
+
+=== "Русский"
+
+    Моя волна — персонализированное бесконечное радио Yandex Music. Оно использует рекомендательный движок Rotor от Яндекса для генерации непрерывного потока треков, подобранных под ваши музыкальные предпочтения.
+
+    ### Как это работает
+
+    1. При открытии Моей волны провайдер запрашивает несколько пачек треков через Rotor API Яндекса (тот же движок, что стоит за «Моей волной» в официальном приложении Yandex Music).
+    2. Каждая пачка содержит несколько треков. Провайдер загружает несколько пачек сразу, чтобы сформировать более длинный плейлист.
+    3. Дубликаты автоматически отфильтровываются — если трек уже был в предыдущей пачке, он не появится снова.
+    4. В Browse внизу отображается кнопка **«Load more»**. Нажатие загружает следующую пачку и добавляет новые треки.
+    5. Максимальное количество треков настраивается (по умолчанию: 150). При достижении лимита загрузка прекращается.
+
+    ### Улучшение рекомендаций
+
+    Провайдер отправляет обратную связь о воспроизведении в Яндекс, аналогично официальному приложению:
+
+    - При **начале воспроизведения** трека Яндекс получает уведомление.
+    - При **завершении** трека (прослушивании до конца) Яндекс засчитывает его как «понравившийся».
+    - При **пропуске** трека (остановка до окончания) Яндекс корректирует будущие рекомендации.
+
+    Обратная связь отправляется автоматически — никаких действий не требуется. Со временем Яндекс изучает ваши предпочтения, и Моя волна становится более персонализированной.
+
+    ### Где отображается Моя волна
+
+    - **Browse** — папка «My Wave» / «Моя волна» в корне Yandex Music. Можно запустить воспроизведение напрямую или просматривать отдельные треки.
+    - **Главная страница (Discover)** — секция рекомендаций «My Wave» с подборкой персонализированных треков.
+    - **Плейлисты библиотеки** — виртуальный плейлист «My Wave» / «Моя волна» всегда отображается в списке плейлистов для быстрого доступа.
+
+    ### Похожие треки (режим радио)
+
+    При запуске режима радио с любого трека Yandex Music провайдер использует движок Rotor для поиска похожих треков. Это работает для любого трека, не только для Моей волны — создаётся станция на основе стиля и жанра конкретного трека.
 
 ## Liked Tracks
 
-Your liked (favorited) tracks are available as a virtual playlist:
+=== "English"
 
-- Sorted in **reverse chronological order** — your most recently liked tracks appear first
-- Always visible in your library playlists and Browse section
-- The maximum number of tracks is configurable (default: 500)
-- Full track details (including album art) are fetched automatically
+    Your liked (favorited) tracks are available as a virtual playlist:
+
+    - Sorted in **reverse chronological order** — your most recently liked tracks appear first
+    - Always visible in your library playlists and Browse section
+    - The maximum number of tracks is configurable (default: 500)
+    - Full track details (including album art) are fetched automatically
+
+=== "Русский"
+
+    Ваши понравившиеся (избранные) треки доступны в виде виртуального плейлиста:
+
+    - Отсортированы в **обратном хронологическом порядке** — недавно добавленные треки отображаются первыми
+    - Всегда видны в плейлистах библиотеки и разделе Browse
+    - Максимальное количество треков настраивается (по умолчанию: 500)
+    - Полная информация о треках (включая обложки) загружается автоматически
 
 ## Picks & Mixes
 
-Picks and Mixes let you browse curated playlists organized by theme, available in the Browse section.
+=== "English"
 
-### Browse structure
+    Picks and Mixes let you browse curated playlists organized by theme, available in the Browse section.
 
-```
-Yandex Music
-├── Picks
-│   ├── Mood — Chill, Sad, Romantic, Party, Relax
-│   ├── Activity — Workout, Focus, Morning, Evening, Driving
-│   ├── Era — 80s, 90s, 2000s, Retro
-│   └── Genres — Rock, Jazz, Classical, Electronic, R&B, Hip-Hop
-└── Mixes
-    └── Seasonal — Winter, Summer, Autumn, New Year
-```
+    ### Browse structure
 
-The categories under Picks contain fixed tags, but additional tags may be discovered dynamically from Yandex Music's catalog (refreshed hourly). These extra tags appear in the Mood category.
+    ```
+    Yandex Music
+    ├── Picks
+    │   ├── Mood — Chill, Sad, Romantic, Party, Relax
+    │   ├── Activity — Workout, Focus, Morning, Evening, Driving
+    │   ├── Era — 80s, 90s, 2000s, Retro
+    │   └── Genres — Rock, Jazz, Classical, Electronic, R&B, Hip-Hop
+    └── Mixes
+        └── Seasonal — Winter, Summer, Autumn, New Year
+    ```
 
-Each tag opens a list of curated playlists you can play directly.
+    The categories under Picks contain fixed tags, but additional tags may be discovered dynamically from Yandex Music's catalog (refreshed hourly). These extra tags appear in the Mood category.
+
+    Each tag opens a list of curated playlists you can play directly.
+
+=== "Русский"
+
+    Подборки и Миксы позволяют просматривать тематические плейлисты в разделе Browse.
+
+    ### Структура Browse
+
+    ```
+    Yandex Music
+    ├── Подборки (Picks)
+    │   ├── Настроение — Chill, Sad, Romantic, Party, Relax
+    │   ├── Активность — Workout, Focus, Morning, Evening, Driving
+    │   ├── Эпоха — 80s, 90s, 2000s, Retro
+    │   └── Жанры — Rock, Jazz, Classical, Electronic, R&B, Hip-Hop
+    └── Миксы (Mixes)
+        └── Сезонные — Winter, Summer, Autumn, New Year
+    ```
+
+    Категории в Подборках содержат фиксированные теги, но дополнительные теги могут обнаруживаться динамически из каталога Yandex Music (обновление каждый час). Дополнительные теги отображаются в категории Mood.
+
+    Каждый тег открывает список тематических плейлистов, которые можно воспроизвести напрямую.
 
 ## Home Page Recommendations
 
-The home page shows up to 9 recommendation sections. All sections are always enabled — there are no toggles to show or hide individual sections.
+=== "English"
 
-| Section | What it shows | How often it refreshes |
-|---------|--------------|----------------------|
-| **My Wave** | Personalized tracks from Rotor AI | Every 10 minutes |
-| **Made for You** | Playlist of the Day, DejaVu, Premiere, and other auto-generated playlists | Every 30 minutes |
-| **Chart** | Current top tracks | Every hour |
-| **New Releases** | Latest album releases | Every hour |
-| **New Playlists** | Fresh editorial playlists | Every hour |
-| **Top Picks** | Top curated playlists (tag: "top") | Every hour |
-| **Mood Mix** | Playlists for a random mood (rotates between chill, sad, romantic, party, relax) | Every 30 minutes |
-| **Activity Mix** | Playlists for a random activity (rotates between workout, focus, morning, evening, driving) | Every 30 minutes |
-| **Seasonal Mix** | Season-appropriate playlists based on the current month (winter, summer, autumn) | Every 6 hours |
+    The home page shows up to 9 recommendation sections. All sections are always enabled — there are no toggles to show or hide individual sections.
 
-The Mood Mix and Activity Mix sections show a different mood/activity each time they refresh, so you'll see variety throughout the day. The Seasonal Mix picks the season based on the current month automatically.
+    | Section | What it shows | How often it refreshes |
+    |---------|--------------|----------------------|
+    | **My Wave** | Personalized tracks from Rotor AI | Every 10 minutes |
+    | **Made for You** | Playlist of the Day, DejaVu, Premiere, and other auto-generated playlists | Every 30 minutes |
+    | **Chart** | Current top tracks | Every hour |
+    | **New Releases** | Latest album releases | Every hour |
+    | **New Playlists** | Fresh editorial playlists | Every hour |
+    | **Top Picks** | Top curated playlists (tag: "top") | Every hour |
+    | **Mood Mix** | Playlists for a random mood (rotates between chill, sad, romantic, party, relax) | Every 30 minutes |
+    | **Activity Mix** | Playlists for a random activity (rotates between workout, focus, morning, evening, driving) | Every 30 minutes |
+    | **Seasonal Mix** | Season-appropriate playlists based on the current month (winter, summer, autumn) | Every 6 hours |
+
+    The Mood Mix and Activity Mix sections show a different mood/activity each time they refresh, so you'll see variety throughout the day. The Seasonal Mix picks the season based on the current month automatically.
+
+=== "Русский"
+
+    На главной странице отображается до 9 секций рекомендаций. Все секции всегда включены — нет переключателей для отображения или скрытия отдельных секций.
+
+    | Секция | Что показывает | Частота обновления |
+    |--------|---------------|-------------------|
+    | **My Wave** | Персонализированные треки от Rotor AI | Каждые 10 минут |
+    | **Made for You** | Плейлист дня, DejaVu, Премьера и другие автоматически сгенерированные плейлисты | Каждые 30 минут |
+    | **Chart** | Текущие популярные треки | Каждый час |
+    | **New Releases** | Последние релизы альбомов | Каждый час |
+    | **New Playlists** | Свежие редакционные плейлисты | Каждый час |
+    | **Top Picks** | Лучшие тематические плейлисты (тег: "top") | Каждый час |
+    | **Mood Mix** | Плейлисты по настроению (ротация: chill, sad, romantic, party, relax) | Каждые 30 минут |
+    | **Activity Mix** | Плейлисты по активности (ротация: workout, focus, morning, evening, driving) | Каждые 30 минут |
+    | **Seasonal Mix** | Сезонные плейлисты на основе текущего месяца (winter, summer, autumn) | Каждые 6 часов |
+
+    Секции Mood Mix и Activity Mix показывают разное настроение/активность при каждом обновлении, обеспечивая разнообразие в течение дня. Seasonal Mix автоматически определяет сезон по текущему месяцу.
 
 ## Lyrics
 
-Lyrics are fetched directly from Yandex Music when viewing track details:
+=== "English"
 
-- **Synced lyrics (LRC)** — With timestamps for karaoke-style synchronized display, when available
-- **Plain text lyrics** — Used as fallback when synced lyrics are not available
-- **Automatic caching** — Lyrics are cached together with track data for 30 days
+    Lyrics are fetched directly from Yandex Music when viewing track details:
 
-!!! note
-    Lyrics availability depends on the track and may vary by region due to licensing restrictions. If lyrics are unavailable for your region, the provider handles this silently without errors.
+    - **Synced lyrics (LRC)** — With timestamps for karaoke-style synchronized display, when available
+    - **Plain text lyrics** — Used as fallback when synced lyrics are not available
+    - **Automatic caching** — Lyrics are cached together with track data for 30 days
+
+    !!! note
+        Lyrics availability depends on the track and may vary by region due to licensing restrictions. If lyrics are unavailable for your region, the provider handles this silently without errors.
+
+=== "Русский"
+
+    Тексты песен загружаются напрямую из Yandex Music при просмотре информации о треке:
+
+    - **Синхронизированные тексты (LRC)** — С временными метками для караоке-стиля отображения, при наличии
+    - **Обычные тексты** — Используются как запасной вариант, когда синхронизированные тексты недоступны
+    - **Автоматическое кэширование** — Тексты кэшируются вместе с данными трека на 30 дней
+
+    !!! note
+        Доступность текстов зависит от трека и может отличаться по регионам из-за лицензионных ограничений. Если тексты недоступны для вашего региона, провайдер обрабатывает это без ошибок.
 
 ## Configuration
 
-### Obtaining the Token
+=== "English"
 
-1. Open your browser and navigate to [Yandex OAuth](https://oauth.yandex.ru/authorize?response_type=token&client_id=23cabbbdc6cd418abb4b39c32c41195d)
-2. Log in with your Yandex account if prompted
-3. After authorization, you will be redirected to a URL containing `access_token=YOUR_TOKEN`
-4. Copy the token value (the part after `access_token=` and before `&`)
-5. Paste this token into the Music Assistant Yandex Music provider configuration
+    ### Obtaining the Token
 
-### Settings
+    1. Open your browser and navigate to [Yandex OAuth](https://oauth.yandex.ru/authorize?response_type=token&client_id=23cabbbdc6cd418abb4b39c32c41195d)
+    2. Log in with your Yandex account if prompted
+    3. After authorization, you will be redirected to a URL containing `access_token=YOUR_TOKEN`
+    4. Copy the token value (the part after `access_token=` and before `&`)
+    5. Paste this token into the Music Assistant Yandex Music provider configuration
 
-The provider has 8 settings. The first 3 are shown by default; the rest are under "Show advanced settings."
+    ### Settings
 
-| Setting | Default | Description |
-|---------|---------|-------------|
-| **Yandex Music Token** | — | Your OAuth token (see above) |
-| **Reset authentication** | — | Clears the saved token so you can re-authenticate |
-| **Audio quality** | Balanced | Choose between Efficient, Balanced, High, or Superb (FLAC) |
+    The provider has 8 settings. The first 3 are shown by default; the rest are under "Show advanced settings."
 
-**Advanced settings** (click "Show advanced settings" to see these):
+    | Setting | Default | Description |
+    |---------|---------|-------------|
+    | **Yandex Music Token** | — | Your OAuth token (see above) |
+    | **Reset authentication** | — | Clears the saved token so you can re-authenticate |
+    | **Audio quality** | Balanced | Choose between Efficient, Balanced, High, or Superb (FLAC) |
 
-| Setting | Default | Description |
-|---------|---------|-------------|
-| **FLAC streaming mode** | Buffered | How encrypted FLAC streams are decoded (Direct, Buffered, or Preload) |
-| **Preload max file size (MB)** | 100 | Only visible when Preload mode is selected. Files larger than this use Buffered mode instead |
-| **My Wave maximum tracks** | 150 | How many tracks to load for My Wave. Lower = faster loading |
-| **Liked Tracks maximum tracks** | 500 | How many liked tracks to show. Lower = faster loading |
-| **API Base URL** | api.music.yandex.net | Only change if Yandex changes their API endpoint |
+    **Advanced settings** (click "Show advanced settings" to see these):
+
+    | Setting | Default | Description |
+    |---------|---------|-------------|
+    | **FLAC streaming mode** | Buffered | How encrypted FLAC streams are decoded (Direct, Buffered, or Preload) |
+    | **Preload max file size (MB)** | 100 | Only visible when Preload mode is selected. Files larger than this use Buffered mode instead |
+    | **My Wave maximum tracks** | 150 | How many tracks to load for My Wave. Lower = faster loading |
+    | **Liked Tracks maximum tracks** | 500 | How many liked tracks to show. Lower = faster loading |
+    | **API Base URL** | api.music.yandex.net | Only change if Yandex changes their API endpoint |
+
+=== "Русский"
+
+    ### Получение токена
+
+    1. Откройте браузер и перейдите на страницу [Yandex OAuth](https://oauth.yandex.ru/authorize?response_type=token&client_id=23cabbbdc6cd418abb4b39c32c41195d)
+    2. Войдите в свой аккаунт Яндекса, если потребуется
+    3. После авторизации вы будете перенаправлены на URL, содержащий `access_token=ВАШ_ТОКЕН`
+    4. Скопируйте значение токена (часть после `access_token=` и перед `&`)
+    5. Вставьте токен в настройки провайдера Yandex Music в Music Assistant
+
+    ### Настройки
+
+    Провайдер имеет 8 настроек. Первые 3 отображаются по умолчанию; остальные доступны через «Show advanced settings».
+
+    | Настройка | По умолчанию | Описание |
+    |-----------|-------------|----------|
+    | **Yandex Music Token** | — | Ваш OAuth-токен (см. выше) |
+    | **Reset authentication** | — | Сбрасывает сохранённый токен для повторной авторизации |
+    | **Audio quality** | Balanced | Выбор между Efficient, Balanced, High или Superb (FLAC) |
+
+    **Расширенные настройки** (нажмите «Show advanced settings»):
+
+    | Настройка | По умолчанию | Описание |
+    |-----------|-------------|----------|
+    | **FLAC streaming mode** | Buffered | Способ дешифровки FLAC-потоков (Direct, Buffered или Preload) |
+    | **Preload max file size (MB)** | 100 | Отображается только при выборе Preload. Файлы больше этого размера используют Buffered |
+    | **My Wave maximum tracks** | 150 | Сколько треков загружать для Моей волны. Меньше = быстрее загрузка |
+    | **Liked Tracks maximum tracks** | 500 | Сколько избранных треков показывать. Меньше = быстрее загрузка |
+    | **API Base URL** | api.music.yandex.net | Менять только если Яндекс изменит адрес API |
 
 ## Localization
 
-All folder and section names automatically adapt to your Music Assistant language:
+=== "English"
 
-- **Russian** (`ru_*` locales): "Моя волна", "Мне нравится", "Подборки", "Миксы", etc.
-- **Other locales**: "My Wave", "My Favorites", "Picks", "Mixes", etc.
+    All folder and section names automatically adapt to your Music Assistant language:
+
+    - **Russian** (`ru_*` locales): "Моя волна", "Мне нравится", "Подборки", "Миксы", etc.
+    - **Other locales**: "My Wave", "My Favorites", "Picks", "Mixes", etc.
+
+=== "Русский"
+
+    Все названия папок и секций автоматически адаптируются к языку Music Assistant:
+
+    - **Русский** (локали `ru_*`): «Моя волна», «Мне нравится», «Подборки», «Миксы» и т.д.
+    - **Другие локали**: «My Wave», «My Favorites», «Picks», «Mixes» и т.д.
 
 ## Known Issues / Notes
 
-- The OAuth token may expire and need to be refreshed periodically
-- During long sessions the API may occasionally disconnect; the provider reconnects automatically
-- Some curated playlists may be unavailable in certain regions due to geo-restrictions
-- Multiple Yandex Music accounts are not yet supported
+=== "English"
+
+    - The OAuth token may expire and need to be refreshed periodically
+    - During long sessions the API may occasionally disconnect; the provider reconnects automatically
+    - Some curated playlists may be unavailable in certain regions due to geo-restrictions
+    - Multiple Yandex Music accounts are not yet supported
+
+=== "Русский"
+
+    - OAuth-токен может истечь и потребовать периодического обновления
+    - При длительных сессиях API может периодически отключаться; провайдер переподключается автоматически
+    - Некоторые тематические плейлисты могут быть недоступны в определённых регионах из-за гео-ограничений
+    - Поддержка нескольких аккаунтов Yandex Music пока не реализована

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -188,6 +188,8 @@ markdown_extensions:
   - footnotes
   - pymdownx.details
   - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
   - pymdownx.mark
   - attr_list
   - pymdownx.magiclink


### PR DESCRIPTION
## Summary

Complete documentation rewrite for the Yandex Music provider — bilingual (English/Russian) with tabs.

## Changes

- **Features table**: Recommendations, Lyrics, Radio Mode set to **Yes**
- **Audio Quality**: 4 quality tiers, FLAC streaming modes (Direct, Buffered, Preload)
- **My Wave**: How it works, rotor feedback, where it appears, radio mode
- **Liked Tracks**: Virtual playlist, reverse chronological order
- **Picks & Mixes**: Dynamic tag discovery from Landing API, category structure, blacklist filtering, `is_playable=False` for navigation folders, cache behavior
- **Recommendations**: All 9 home page sections with refresh intervals
- **Lyrics**: Synced LRC + plain text, caching, geo-restrictions
- **Configuration**: All 9 settings documented (basic + advanced), including new **Stream buffer size (MB)** for Buffered mode
- **Localization**: Automatic RU/EN folder names
- **Known Issues**: Token expiry, API reconnect, geo-restrictions

### MkDocs extension

Added `pymdownx.tabbed` with `alternate_style: true` for bilingual tabs.

---

**Related:**
- [server PR #3147 — Yandex Music: FLAC, Lyrics, Picks & Mixes, recommendations](https://github.com/music-assistant/server/pull/3147)
- [server PR #3122 — Yandex Music: My Wave Browse folder and locale-based names](https://github.com/music-assistant/server/pull/3122)